### PR TITLE
Reuse cleanup, model-retirement monitor, mobile responsive UI, doc cl…

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "frontend",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 5173,
+      "cwd": "frontend"
+    }
+  ]
+}

--- a/.features/done/ai_personality_option.md
+++ b/.features/done/ai_personality_option.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Planned (sketched 2026-06-22). Not started. Post-core polish / portfolio flair.
+Planned (sketched 2026-06-22). Not started. Post-core polish.
 
 ## Objective
 
@@ -19,8 +19,8 @@ prompt.
 
 The app is already themed as "Oracle Rex," a sci-fi command console (see
 `milestone_7_ux_theme.md`). A selectable AI persona is a cheap, memorable
-portfolio differentiator that rides on top of the existing prompt layer with no
-change to the game logic or schemas.
+differentiator that rides on top of the existing prompt layer with no change to
+the game logic or schemas.
 
 ## Proposed personas
 

--- a/.features/done/api_model_retirement_monitor.md
+++ b/.features/done/api_model_retirement_monitor.md
@@ -2,7 +2,25 @@
 
 ## Status
 
-Planned (sketched 2026-06-22). Not started.
+Done (2026-06-23). Implemented as `scripts/check_model_availability.py` (stdlib
+only, imports `config.py` as the watch list) plus
+`.github/workflows/model-retirement-check.yml` (weekly cron + `workflow_dispatch`,
+job-fail alerting). Two refinements over the original sketch:
+
+- **Google / Gemini is also checked.** `config.py` now has `GEMINI_MODELS`
+  served by a server-held key, and a retired Gemini model would silently break
+  the free live-demo path. The script lists all four providers (Gemini via
+  `generativelanguage.googleapis.com/v1beta/models`, a different response shape).
+- **Matching is date-suffix aware, not bare prefix.** A configured id is present
+  only if a live id equals it or appends `-<date>` (e.g. `claude-haiku-4-5` ->
+  `claude-haiku-4-5-20251001`). Bare prefix matching would let `gpt-5.4-mini`
+  satisfy a retired `gpt-5.4` and hide the retirement.
+
+Exit codes: 0 = all present; 1 = a model is missing (the alert); 2 = a provider
+could not be checked (missing key / API error). `--allow-missing-keys` lets a
+local run skip providers whose key is absent; CI runs without it so a missing
+secret surfaces. Remaining manual step: add the four API keys as repository
+secrets, then trigger once via `workflow_dispatch` to confirm a clean pass.
 
 ## Objective
 
@@ -86,7 +104,7 @@ miss.
   be prefix-aware (configured id is a prefix of a live id) or it will
   false-positive. Same care for the xAI / Grok ids.
 - GitHub disables scheduled workflows after 60 days of repo inactivity. Not a
-  concern for an active repo, but worth knowing for a dormant portfolio project.
+  concern for an active repo, but worth knowing for a dormant project.
 
 ## Build steps
 

--- a/.features/done/milestone_10_game_features.md
+++ b/.features/done/milestone_10_game_features.md
@@ -48,8 +48,8 @@ A structured, vendorable source exists — confirmed, no rulebook scraping neede
     assets**. So: vendor the **mechanical JSON only**, **never the images**
     (those remain Asmodee/FFG IP — and we already serve our own tile/unit art).
   - ⚠️ The Unlicense waives the *repo authors'* rights, but the underlying game
-    content is Asmodee IP. For a personal/portfolio project a mechanical subset
-    is low-risk; keep to **facts/mechanics (tech name, prereqs, type, stat
+    content is Asmodee IP. For a personal, non-commercial project a mechanical
+    subset is low-risk; keep to **facts/mechanics (tech name, prereqs, type, stat
     effects), not flavor text**, and **attribute the source** anyway (as done for
     Milty Draft in M4) for good hygiene.
 

--- a/.features/done/mobile_responsive_ui.md
+++ b/.features/done/mobile_responsive_ui.md
@@ -1,0 +1,122 @@
+# Feature: Mobile / small-screen responsive UI
+
+## Status
+
+Done (2026-06-23). Diagnosed from two owner-supplied iPhone screenshots
+(~390px width, portrait); root causes confirmed below. All fixes land behind a
+single `@media (max-width: 640px)` block per module and leave every desktop rule
+untouched. Verified in a 375px preview (tabs wrap to 2x3 and are all reachable,
+the full 37-hex board fits with zero horizontal overflow and a ~319px height
+instead of 160vh, the TTS row stacks) and at 1345px desktop (hex width still
+168px = 12.5vw, grid still 80vw x 160vh, tabs still `nowrap` — i.e. desktop
+pixel-identical). tsc / eslint / 79 tests pass.
+
+Design call (owner): the board hexes deliberately keep their `6.5vw` font size on
+mobile rather than shrinking — small phones zoom to read individual tiles. The
+mobile board fix only retargets the grid BOX (full content width, content-height
+instead of 160vh) so the map fits and stops ballooning the scroll.
+
+### Files changed
+
+- `components/TabNav/TabNav.module.css` — wrap to two rows of three, smaller type.
+- `components/Board/Board.module.css` — mobile grid box `width: 100%`,
+  `height: 85vw`, `.boardPreview min-height: 0`; hex size/offsets untouched.
+- `App.module.css` — reduced `.container` side padding, smaller `.title`.
+- `features/battleCalculator/BattleCalculator.module.css` — `.section min-width:
+  0` so fleets stack; tighter unit-grid gaps.
+- `features/strategicPlan/StrategyPanel.module.css` — `.ttsRow` stacks the input
+  above the Generate button.
+
+(Original diagnosis retained below for reference.)
+
+## Problem
+
+On a phone the page does not reflow to the narrow viewport. The viewport meta is
+correct (`width=device-width, initial-scale=1.0` in `frontend/index.html`), so
+the page renders at device width, but the layout was built desktop-first and is
+almost entirely non-responsive (repo-wide, `@media` rules exist only in
+`LoadingState.module.css` and `AdvisorCard.module.css`). Two things actually
+break, plus secondary cramping.
+
+## Confirmed issues
+
+### 1. Tab bar overflows and hides two tabs (functional, highest priority)
+
+There are **six** tabs (`App.tsx` `TABS`): Settings, Rules Q&A, Strategy
+Suggester, Fleet Manager, Move Suggester, Tactical Calculator. In
+`TabNav.module.css`, `.tabButton` is `flex: 1` with `font-size: 16px` and
+`.tabNav` has no `flex-wrap` and no `overflow-x`. Flex items default to
+`min-width: auto`, so each tab can't shrink below its widest word; the row's
+min-content width exceeds ~390px and overflows to the right, clipping the bar.
+
+Screenshot 1 confirms it: only Settings / Rules Q&A / Strategy Suggester are
+fully visible, "Fleet Manager" is clipped mid-word, and **Move Suggester and
+Tactical Calculator are off-screen with no way to scroll to them** — two features
+are unreachable on mobile.
+
+### 2. Board hex map overflows width and balloons vertically
+
+`Board.module.css` sizes the map in viewport units tuned for a wide landscape
+desktop:
+- `.hexGrid { width: 80vw; height: 160vh; font-size: 6.5vw; }`
+- `--hex-grid-width: 12.5vw`, with all 37 hex positions offset in `em`
+  (`--hex-grid-vert: 1.68em`, `--hex-grid-horz: 1.46em`), i.e. relative to that
+  `6.5vw` font size.
+- `.boardPreview { min-height: 90vh; }`
+
+Hex size (`vw`) and ring spacing (`em` off a `vw` font) scale on different
+references, so the proportion that works in landscape breaks in narrow portrait:
+the outer ring extends past the 80vw width and the left/right hexes clip at the
+viewport edge (screenshot 2). Separately, `height: 160vh` + `min-height: 90vh`
+force an enormous vertical scroll — screenshot 2 is nothing but board.
+
+### 3. Secondary cramping (lower priority)
+
+- **Shell padding.** `App.module.css` `.container` uses `padding: 34px 38px 44px`;
+  the 38px side padding eats ~20% of a phone's width.
+- **Fleet columns.** `BattleCalculator.module.css` `.section` has
+  `min-width: 320px` in a flex-wrap row; two side-by-side fleets force horizontal
+  overflow below ~660px. (Not in these screenshots, but will break the Tactical
+  Calculator tab.)
+- **Side-by-side input rows.** Strategy's `.ttsRow` (input + button) does not
+  stack; it squeezes on a narrow screen.
+- **Title size.** The Azonix `h1` is large and wraps to four lines; optional
+  shrink at the small breakpoint.
+
+## Approach
+
+Add `@media (max-width: 640px)` (and possibly a `~960px` step for the fleet
+columns) blocks; do not alter the existing desktop rules.
+
+1. **Tabs (`TabNav.module.css`).** Make all six tabs reachable on mobile. Either
+   (a) `flex-wrap: wrap` so they flow onto 2 rows, or (b) `overflow-x: auto` +
+   `flex-wrap: nowrap` for a single swipeable row. Reduce `.tabButton`
+   `font-size` (~13px) and side padding at the breakpoint. Recommend wrapping —
+   no hidden tabs, no discoverability problem. Confirm the active-underline
+   (`.active::after`) still reads when wrapped.
+2. **Board (`Board.module.css`).** At the small breakpoint, retune the hex-grid
+   scale so the assembled map fits the content width with no horizontal overflow
+   and a height proportional to its real content: override `.hexGrid`
+   `font-size` / `width` / `height` and `--hex-grid-width` together (they must be
+   re-related so hex size and `em` ring offsets stay consistent), and lower
+   `.boardPreview min-height`. Values tuned empirically against ~390px until the
+   full 37-hex map is visible and centered. Verify Fleet Manager hex hit targets
+   and the `:hover`/`.active` scale still behave.
+3. **Shell (`App.module.css`).** Reduce `.container` padding (~16px sides) at the
+   breakpoint; keep the corner brackets sensible.
+4. **Fleet + input rows.** At the breakpoint, drop/lower `.section`
+   `min-width: 320px` and stack the fleets one per row; stack `.ttsRow` (full-
+   width input above full-width button).
+5. **Title.** Optional `h1` font-size reduction at the breakpoint.
+6. **Verify** on a real ~390px viewport against both screenshots; confirm desktop
+   (>= the breakpoint) renders identically to today and existing tests pass.
+
+## Acceptance criteria
+
+- All six tabs are reachable and legible on a phone (no clipped/hidden tabs).
+- The board map fits the width with no horizontal overflow and a reasonable
+  height; the full 37-hex layout is visible and centered.
+- Tactical Calculator fleets, Strategy TTS input, and result cards are usable on
+  a narrow screen with no horizontal overflow.
+- Desktop layout at/above the breakpoint is visually unchanged; existing tests
+  still pass.

--- a/.features/done/phase_6_implementation.md
+++ b/.features/done/phase_6_implementation.md
@@ -338,8 +338,9 @@ Once the math is deterministic, the LLM's job changes from *compute* to
   summary / key_factors / threats / advice), rendered as an AdvisorCard like the
   other features — a cleaner result than the legacy text format. This is optional
   but recommended; bump `PROMPT_VERSIONS["tac_calc"]`.
-- This is the "deterministic sim + LLM narration" pairing that makes the resume
-  bullet ("Optimized combat calculator workflows … probability thresholds …") true.
+- This is the "deterministic sim + LLM narration" pairing: the win odds and
+  recommended fleet compositions come from real probability math, with the LLM
+  narrating the computed numbers rather than guessing them.
 
 ### 6C.4 — Demo mode simplification
 
@@ -369,8 +370,8 @@ the result live instead of serving a cached one. The cached demo response
   sustain-damage assignment order, bombardment vs. Planetary Shield) against the
   rules rather than inheriting the prompt's approximations.
 - **Where the sim runs: backend (recommended).** Python backend keeps the logic
-  testable in the existing test suite and supports the "productionized backend
-  combat simulator" portfolio story. A frontend TS sim would be even faster and
+  testable in the existing test suite and keeps the combat simulator in the
+  productionized backend. A frontend TS sim would be even faster and
   offline-capable but duplicates rules logic and moves it out of the tested
   Python core. Recommend backend.
 - **Monte Carlo vs exact.** Monte Carlo first (simpler, fast enough). Note exact

--- a/.features/done/react_reuse_cleanup.md
+++ b/.features/done/react_reuse_cleanup.md
@@ -2,7 +2,10 @@
 
 ## Status
 
-Planned (2026-06-22). Not started. Optional polish, not a gap.
+Done (2026-06-23). Extracted `JobResultArea`, `DemoBox`, and `EmptyHint`
+components; the four panels and their CSS modules now route the result-area
+ladder, demo callout, and empty-hint styling through them. tsc / eslint / 79
+tests all pass; behavior and appearance unchanged.
 
 ## Context
 

--- a/.features/done/tactical_calculator_caps_and_reset.md
+++ b/.features/done/tactical_calculator_caps_and_reset.md
@@ -2,8 +2,18 @@
 
 ## Status
 
-Planned (2026-06-22). Not started. Two related UX improvements, anchored on the
-Tactical Calculator.
+Two related UX improvements, anchored on the Tactical Calculator.
+
+- **Part A (unit caps): DONE** (2026-06-23). Implemented and verified (77 frontend
+  tests). Caps confirmed against the rules: War Sun 2, Flagship 1, Carrier 4,
+  Dreadnought 5, Cruiser 8, Destroyer 8, PDS 6, Space Dock 3, Mech 4; Fighters and
+  Infantry uncapped. `UnitDef.max` drives a disabled up-arrow + a clamp in
+  `increment`.
+- **Part B (per-tab reset): DONE** (2026-06-23). Implemented and verified (79
+  frontend tests). A shared `ResetButton` (with a themed confirm dialog) on Rules,
+  Strategy, Move, Fleet Manager, and Tactical Calculator clears that tab's state;
+  Settings is excluded (it would wipe API keys). `useBoardSuggester` gained a
+  `reset()` for the two board panels.
 
 ---
 
@@ -88,7 +98,7 @@ to every feature tab.
 
 - A small reusable confirmation step. Two options: a themed `ConfirmDialog`
   component (matches the console theme, preferred) or `window.confirm` as a
-  minimal fallback. Recommend the themed dialog for portfolio polish.
+  minimal fallback. Recommend the themed dialog for a more polished feel.
 - A shared `ResetButton` placed consistently per tab; the actual reset logic lives
   in each panel since each owns its state.
 

--- a/.features/oracle_rex_upgrade_plan.md
+++ b/.features/oracle_rex_upgrade_plan.md
@@ -2,9 +2,9 @@
 
 ## Purpose
 
-Modernize Oracle Rex from an older AI demo into a polished, reliable, portfolio-ready AI strategy assistant for Twilight Imperium.
+Modernize Oracle Rex from an older AI demo into a polished, reliable AI strategy assistant for Twilight Imperium.
 
-The goal is **not** to add a large number of new features. The priority is to make the existing app reliable, maintainable, easier to demo, and technically impressive as a portfolio project.
+The goal is **not** to add a large number of new features. The priority is to make the existing app reliable, maintainable, easier to demo, and technically solid.
 
 ## Current Major Features
 
@@ -61,7 +61,7 @@ Follow these principles during the upgrade:
 - Separate prompts, model calls, response schemas, and UI rendering.
 - Treat long-running AI calls as asynchronous jobs or streaming responses, not normal blocking web requests.
 - Make the public demo safe by default: no owner-paid API key exposed to anonymous users.
-- Provide sample scenarios so non-TI interviewers can understand the app quickly.
+- Provide sample scenarios so people unfamiliar with TI can understand the app quickly.
 - Add tests around parsing, data correctness, and calculator behavior.
 
 ---
@@ -374,11 +374,11 @@ completed_at
 
 ---
 
-# Milestone 3 — Demo Mode and Portfolio Usability
+# Milestone 3 — Demo Mode and Usability
 
 ## Objective
 
-Make the hosted app usable by interviewers without requiring API keys or Twilight Imperium setup knowledge.
+Make the hosted app usable by first-time visitors without requiring API keys or Twilight Imperium setup knowledge.
 
 ## Required Modes
 
@@ -401,7 +401,7 @@ Implement or clearly support three modes:
 
 Optional but useful.
 
-- Owner-controlled access for interviews.
+- Owner-controlled access for sharing a live demo.
 - Could use an access code or environment flag.
 - Uses backend API key with strict limits.
 
@@ -500,8 +500,8 @@ If private live demo mode is implemented, add:
 
 ## Acceptance Criteria
 
-- An interviewer can open the app and try each major feature without an API key.
-- An interviewer does not need to know what a TTS string is.
+- A first-time visitor can open the app and try each major feature without an API key.
+- A first-time visitor does not need to know what a TTS string is.
 - Demo mode cannot run up owner AI costs.
 - Live AI remains available through BYOK or controlled private access.
 
@@ -773,7 +773,7 @@ Example:
 The AI request failed. You can retry, switch to demo mode, or provide your own API key in Live AI Mode.
 ```
 
-### Portfolio-Friendly Landing Page
+### Landing Page
 
 Add a short landing page or intro section:
 
@@ -844,11 +844,11 @@ npm run build
 
 ---
 
-# Milestone 9 — Portfolio Packaging
+# Milestone 9 — Documentation and Packaging
 
 ## Objective
 
-Make the upgraded project easy to understand for recruiters/interviewers.
+Make the upgraded project easy to understand for new visitors and contributors.
 
 ## Tasks
 
@@ -908,9 +908,9 @@ React Frontend
 
 ## Acceptance Criteria
 
-- Portfolio page can link to app, GitHub, screenshots, and walkthrough video.
+- README/project page can link to app, GitHub, screenshots, and walkthrough video.
 - Public demo works without API keys.
-- Technical story is clear to a non-TI interviewer.
+- Technical story is clear to someone unfamiliar with TI.
 
 ---
 
@@ -1071,7 +1071,7 @@ Use this order when working through the project:
 9. Migrate each feature into React one at a time.
 10. Optimize calculator/board rendering performance where needed.
 11. Improve UX/theme and advisor result cards.
-12. Add screenshots, README updates, and portfolio packaging.
+12. Add screenshots, README updates, and project documentation.
 
 ---
 
@@ -1087,5 +1087,5 @@ The upgrade is complete when:
 - AI outputs are structured and validated.
 - Planet/system/tile data mismatches are fixed and covered by validation.
 - Battle calculator and board rendering are responsive enough for demo use.
-- README, screenshots, and portfolio story are updated.
+- README, screenshots, and project documentation are updated.
 - Project can be explained as a productionized AI decision-support app, not just a chatbot wrapper.

--- a/.github/workflows/model-retirement-check.yml
+++ b/.github/workflows/model-retirement-check.yml
@@ -1,0 +1,32 @@
+name: Model retirement check
+
+# Layer 2 backstop for AI model retirements (see
+# .features/done/api_model_retirement_monitor.md). Weekly, plus on demand, it
+# checks that every model in core/service/ai/config.py is still served by its
+# provider. A missing model fails the job, and GitHub emails the repo owner when
+# a scheduled workflow fails.
+
+on:
+  schedule:
+    # Mondays at 13:00 UTC. Cron is UTC-only on GitHub Actions.
+    - cron: "0 13 * * 1"
+  workflow_dispatch:
+
+jobs:
+  check-models:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13.2"
+      # The script is stdlib-only and imports config.py directly, so there is no
+      # dependency install step.
+      - name: Check configured models against live provider lists
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        run: python scripts/check_model_availability.py

--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ Oracle Rex supports three modes so it can be explored with or without an API key
 - **Live AI (BYOK)** — paste your own provider API key in **Settings** to generate
   fresh responses. Keys stay in the browser and are sent only with your own
   requests (encrypted on the backend before the job runs; never stored).
-- **Private live demo** — for interviews: an owner-set access code unlocks a
-  controlled backend key behind a cheap model, an output-token cap, and a daily
-  request limit (see the live-demo env vars under *Deployment*).
+- **Private live demo** — an owner-set access code unlocks a controlled backend
+  key behind a cheap model, an output-token cap, and a daily request limit (see
+  the live-demo env vars under *Deployment*). Lets you share a live demo without
+  exposing your own key.
 
 The following tabs make up all the functions of this application:
   
@@ -160,9 +161,9 @@ Optional environment variables:
 Demo mode needs no configuration — the sample scenarios and cached responses live
 in [`core/demo/`](core/demo) and are served by the `/api/demo/` endpoints.
 
-The optional **private live demo** lets an interviewer run *live* AI on the
-owner's key without exposing it. It is **off unless both** an access code and a
-backend key are set:
+The optional **private live demo** lets someone with the access code run *live*
+AI on the owner's key without exposing it. It is **off unless both** an access
+code and a backend key are set:
 
 - `DEMO_LIVE_ACCESS_CODE` — code a user enters in Settings to unlock live AI on
   the owner's key.

--- a/frontend/src/App.module.css
+++ b/frontend/src/App.module.css
@@ -81,3 +81,16 @@
 .tagline strong {
   color: var(--accent-amber);
 }
+
+/* Mobile: reclaim the ~20% of width the desktop side padding eats on a phone,
+   and trim the oversized title so it doesn't dominate the first screen. */
+@media (max-width: 640px) {
+  .container {
+    padding: 20px 16px 28px;
+  }
+
+  .title {
+    font-size: 1.6rem;
+    letter-spacing: 1px;
+  }
+}

--- a/frontend/src/components/Board/Board.module.css
+++ b/frontend/src/components/Board/Board.module.css
@@ -42,6 +42,30 @@
   font-size: 6.5vw;
 }
 
+/* Mobile: the desktop board is sized for a wide landscape viewport
+   (width: 80vw, height: 160vh, font-size: 6.5vw). In narrow portrait that 160vh
+   balloons into a screen-filling vertical scroll, and the 80vw box can nudge
+   past the padded container width and clip the edge hexes.
+
+   Per the design call, the hexes deliberately keep their 6.5vw font size on
+   mobile (so they do NOT shrink relative to desktop — small phones zoom to read
+   the tiles). We only retarget the grid BOX: full content width so it can never
+   overflow the container, and a height that matches the map's actual ~76vw
+   vertical extent instead of 160vh, removing the huge empty scroll. The em-based
+   hex offsets are untouched, so the layout is identical, just no longer adrift
+   in a giant container. Desktop rules above are unchanged. */
+@media (max-width: 640px) {
+  .boardPreview {
+    min-height: 0;
+    margin: 12px 0;
+  }
+
+  .hexGrid {
+    width: 100%;
+    height: 85vw;
+  }
+}
+
 .hex {
   font-size: inherit;
   position: absolute;

--- a/frontend/src/components/DemoBox/DemoBox.module.css
+++ b/frontend/src/components/DemoBox/DemoBox.module.css
@@ -1,0 +1,44 @@
+/* The "try it with no setup" callout shared by the advisor panels and the
+   Tactical Calculator. Owns the box chrome, heading, description, and the demo
+   action button (was copy-pasted as `.demoBox` / `.demoButton` in each panel's
+   module). */
+
+.demoBox {
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(95, 208, 255, 0.12);
+  border-radius: 5px;
+  padding: 12px 16px;
+  margin: 0 0 20px;
+}
+
+.demoBox h4 {
+  margin: 0 0 8px;
+  color: var(--text-muted);
+}
+
+.desc {
+  margin: 0 0 12px;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+.button {
+  font-family: 'Orbitron', sans-serif;
+  background: var(--accent-cyan);
+  color: #02060c;
+  padding: 10px 20px;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+  transition: 0.15s ease;
+}
+
+.button:hover:not(:disabled) {
+  background: #8fe0ff;
+  box-shadow: 0 0 16px rgba(95, 208, 255, 0.4);
+}
+
+.button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/frontend/src/components/DemoBox/DemoBox.tsx
+++ b/frontend/src/components/DemoBox/DemoBox.tsx
@@ -1,0 +1,50 @@
+import type { ReactNode } from 'react'
+
+import styles from './DemoBox.module.css'
+
+// The "try it instantly, no API key" callout that fronts each feature panel.
+// The common case is a heading + description + single demo button (Strategy,
+// Move, Tactical Calculator). RulesPanel has a heading over a row of sample-
+// question chips instead, so when `children` is supplied they render in place of
+// the description/button.
+
+export interface DemoBoxProps {
+  title: string
+  /** Description + button form (omit when passing `children`). */
+  description?: string
+  buttonLabel?: string
+  onClick?: () => void
+  disabled?: boolean
+  /** Custom body (e.g. the Rules sample-question chips) in place of the button. */
+  children?: ReactNode
+}
+
+export function DemoBox({
+  title,
+  description,
+  buttonLabel,
+  onClick,
+  disabled,
+  children,
+}: DemoBoxProps) {
+  return (
+    <div className={styles.demoBox}>
+      <h4>{title}</h4>
+      {children ?? (
+        <>
+          {description && <p className={styles.desc}>{description}</p>}
+          {buttonLabel && (
+            <button
+              type="button"
+              className={styles.button}
+              onClick={onClick}
+              disabled={disabled}
+            >
+              {buttonLabel}
+            </button>
+          )}
+        </>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/EmptyHint/EmptyHint.module.css
+++ b/frontend/src/components/EmptyHint/EmptyHint.module.css
@@ -1,0 +1,12 @@
+/* The empty-state hint box shown before a panel has any result. Shared across
+   the advisor panels and the Tactical Calculator (was copy-pasted as `.hint` in
+   each panel's module). */
+
+.hint {
+  margin: 0;
+  padding: 15px;
+  background: rgba(95, 208, 255, 0.04);
+  border: 1px solid rgba(95, 208, 255, 0.18);
+  border-radius: 6px;
+  color: var(--text-muted);
+}

--- a/frontend/src/components/EmptyHint/EmptyHint.tsx
+++ b/frontend/src/components/EmptyHint/EmptyHint.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from 'react'
+
+import styles from './EmptyHint.module.css'
+
+// The placeholder shown in a panel's result area before anything has been
+// computed (e.g. "Your answer will appear here."). One box, shared across the
+// advisor panels and the Tactical Calculator so the empty-state styling lives in
+// a single place.
+
+export interface EmptyHintProps {
+  children: ReactNode
+}
+
+export function EmptyHint({ children }: EmptyHintProps) {
+  return <p className={styles.hint}>{children}</p>
+}

--- a/frontend/src/components/JobResultArea/JobResultArea.tsx
+++ b/frontend/src/components/JobResultArea/JobResultArea.tsx
@@ -1,0 +1,57 @@
+import { CREDENTIAL_HINT, ErrorState, RETRY_HINT } from '../ErrorState/ErrorState'
+import { EmptyHint } from '../EmptyHint/EmptyHint'
+import { JobResultView } from '../JobResultView/JobResultView'
+import { LoadingState } from '../LoadingState/LoadingState'
+import type { UseAiJobResult } from '../../hooks/useAiJob'
+import type { FeatureType } from '../../types/ai'
+
+// The shared result-area ladder for an AI job: a credential error, then the
+// loading / job-error / success / empty states, in priority order. RulesPanel,
+// StrategyPanel, MovePanel, and BattleCalculator all rendered this same branch
+// by hand; this collapses it to one component so the states (and their hint
+// copy) stay consistent. The credential check is optional because a panel may
+// resolve credentials elsewhere (or not need them).
+
+export interface JobResultAreaProps {
+  job: UseAiJobResult
+  feature: FeatureType
+  loadingMessage: string
+  /** Re-run the job after a job-level error. */
+  onJobRetry: () => void
+  /** A pre-job credential failure (no key / access code), if any. */
+  credentialError?: string
+  /** Retry handler for the credential error (often the same as onJobRetry). */
+  onCredentialRetry?: () => void
+  /** Placeholder text shown before the first result. Omit to render nothing. */
+  emptyHint?: string
+}
+
+export function JobResultArea({
+  job,
+  feature,
+  loadingMessage,
+  onJobRetry,
+  credentialError,
+  onCredentialRetry,
+  emptyHint,
+}: JobResultAreaProps) {
+  if (credentialError) {
+    return (
+      <ErrorState
+        message={credentialError}
+        onRetry={onCredentialRetry}
+        hint={CREDENTIAL_HINT}
+      />
+    )
+  }
+  if (job.isLoading) {
+    return <LoadingState message={loadingMessage} />
+  }
+  if (job.phase === 'error' && job.error) {
+    return <ErrorState message={job.error} onRetry={onJobRetry} hint={RETRY_HINT} />
+  }
+  if (job.phase === 'success' && job.result) {
+    return <JobResultView feature={feature} result={job.result} />
+  }
+  return emptyHint ? <EmptyHint>{emptyHint}</EmptyHint> : null
+}

--- a/frontend/src/components/TabNav/TabNav.module.css
+++ b/frontend/src/components/TabNav/TabNav.module.css
@@ -42,3 +42,18 @@
   background: var(--accent-cyan);
   box-shadow: 0 0 10px var(--accent-cyan);
 }
+
+/* Mobile: six tabs cannot fit one row at 16px on a phone. As an equal-flex row
+   they overflow and clip the trailing tabs off-screen (unreachable). Wrap to two
+   rows of three and shrink the type so every tab stays visible and tappable. */
+@media (max-width: 640px) {
+  .tabNav {
+    flex-wrap: wrap;
+  }
+
+  .tabButton {
+    flex: 1 1 33%;
+    padding: 10px 4px;
+    font-size: 13px;
+  }
+}

--- a/frontend/src/features/battleCalculator/BattleCalculator.module.css
+++ b/frontend/src/features/battleCalculator/BattleCalculator.module.css
@@ -7,26 +7,6 @@
   line-height: 1.5;
 }
 
-.demoBox {
-  background: rgba(255, 255, 255, 0.02);
-  border: 1px solid rgba(95, 208, 255, 0.12);
-  border-radius: 5px;
-  padding: 12px 16px;
-  margin: 0 0 20px;
-}
-
-.demoBox h4 {
-  margin: 0 0 8px;
-  color: var(--text-muted);
-}
-
-.demoDesc {
-  margin: 0 0 12px;
-  color: var(--text-muted);
-  line-height: 1.5;
-}
-
-.demoButton,
 .calculate {
   font-family: 'Orbitron', sans-serif;
   background: var(--accent-cyan);
@@ -38,13 +18,11 @@
   transition: 0.15s ease;
 }
 
-.demoButton:hover:not(:disabled),
 .calculate:hover:not(:disabled) {
   background: #8fe0ff;
   box-shadow: 0 0 16px rgba(95, 208, 255, 0.4);
 }
 
-.demoButton:disabled,
 .calculate:disabled {
   opacity: 0.5;
   cursor: not-allowed;
@@ -98,11 +76,14 @@
   margin-top: 20px;
 }
 
-.hint {
-  margin: 0;
-  padding: 15px;
-  background: rgba(95, 208, 255, 0.04);
-  border: 1px solid rgba(95, 208, 255, 0.18);
-  border-radius: 6px;
-  color: var(--text-muted);
+/* Mobile: the 320px min-width fleet columns overflow a phone's width. Let them
+   shrink and stack one per row, and tighten the unit grid gaps. */
+@media (max-width: 640px) {
+  .section {
+    min-width: 0;
+  }
+
+  .units {
+    gap: 10px 12px;
+  }
 }

--- a/frontend/src/features/battleCalculator/BattleCalculator.tsx
+++ b/frontend/src/features/battleCalculator/BattleCalculator.tsx
@@ -1,12 +1,10 @@
 import { useState } from 'react'
 import { useMutation } from '@tanstack/react-query'
 
-import {
-  CREDENTIAL_HINT,
-  ErrorState,
-  RETRY_HINT,
-} from '../../components/ErrorState/ErrorState'
-import { JobResultView } from '../../components/JobResultView/JobResultView'
+import { DemoBox } from '../../components/DemoBox/DemoBox'
+import { EmptyHint } from '../../components/EmptyHint/EmptyHint'
+import { ErrorState, RETRY_HINT } from '../../components/ErrorState/ErrorState'
+import { JobResultArea } from '../../components/JobResultArea/JobResultArea'
 import { LoadingState } from '../../components/LoadingState/LoadingState'
 import { ResetButton } from '../../components/ResetButton/ResetButton'
 import { UnitCounter } from '../../components/UnitCounter/UnitCounter'
@@ -139,21 +137,16 @@ export function BattleCalculator() {
         <strong>Load Example Battle</strong> to preload a scenario.
       </p>
 
-      <div className={styles.demoBox}>
-        <h4>Or load an example battle (instant)</h4>
-        <p className={styles.demoDesc}>
-          {demoScenario?.description ??
-            'Preloads both fleets and computes the combat odds.'}
-        </p>
-        <button
-          type="button"
-          className={styles.demoButton}
-          onClick={handleDemo}
-          disabled={!demoReady || sim.isPending}
-        >
-          Load Example Battle
-        </button>
-      </div>
+      <DemoBox
+        title="Or load an example battle (instant)"
+        description={
+          demoScenario?.description ??
+          'Preloads both fleets and computes the combat odds.'
+        }
+        buttonLabel="Load Example Battle"
+        onClick={handleDemo}
+        disabled={!demoReady || sim.isPending}
+      />
 
       <h3>Fleets</h3>
       <div className={styles.fleets}>
@@ -201,29 +194,20 @@ export function BattleCalculator() {
           <ErrorState message={simError} onRetry={handleCalculate} hint={RETRY_HINT} />
         ) : sim.data ? (
           <BattleResult result={sim.data}>
-            {credentialError ? (
-              <ErrorState
-                message={credentialError}
-                onRetry={handleCalculate}
-                hint={CREDENTIAL_HINT}
-              />
-            ) : job.isLoading ? (
-              <LoadingState message={EXPLAIN_LOADING_MESSAGE} />
-            ) : job.phase === 'error' && job.error ? (
-              <ErrorState
-                message={job.error}
-                onRetry={handleCalculate}
-                hint={RETRY_HINT}
-              />
-            ) : job.phase === 'success' && job.result ? (
-              <JobResultView feature="tac_calc" result={job.result} />
-            ) : null}
+            <JobResultArea
+              job={job}
+              feature="tac_calc"
+              loadingMessage={EXPLAIN_LOADING_MESSAGE}
+              onJobRetry={handleCalculate}
+              credentialError={credentialError}
+              onCredentialRetry={handleCalculate}
+            />
           </BattleResult>
         ) : (
-          <p className={styles.hint}>
+          <EmptyHint>
             Odds of Victory: not yet calculated. Set your fleets and click Calculate, or
             load the example battle.
-          </p>
+          </EmptyHint>
         )}
       </div>
     </section>

--- a/frontend/src/features/rulesChat/RulesPanel.module.css
+++ b/frontend/src/features/rulesChat/RulesPanel.module.css
@@ -7,19 +7,6 @@
   line-height: 1.5;
 }
 
-.demoBox {
-  background: rgba(255, 255, 255, 0.02);
-  border: 1px solid rgba(95, 208, 255, 0.12);
-  border-radius: 5px;
-  padding: 12px 16px;
-  margin: 0 0 20px;
-}
-
-.demoBox h4 {
-  margin: 0 0 8px;
-  color: var(--text-muted);
-}
-
 .chips {
   display: flex;
   flex-wrap: wrap;
@@ -83,13 +70,4 @@
 
 .results {
   margin-top: 20px;
-}
-
-.hint {
-  margin: 0;
-  padding: 15px;
-  background: rgba(95, 208, 255, 0.04);
-  border: 1px solid rgba(95, 208, 255, 0.18);
-  border-radius: 6px;
-  color: var(--text-muted);
 }

--- a/frontend/src/features/rulesChat/RulesPanel.tsx
+++ b/frontend/src/features/rulesChat/RulesPanel.tsx
@@ -1,12 +1,7 @@
 import { useState } from 'react'
 
-import {
-  CREDENTIAL_HINT,
-  ErrorState,
-  RETRY_HINT,
-} from '../../components/ErrorState/ErrorState'
-import { JobResultView } from '../../components/JobResultView/JobResultView'
-import { LoadingState } from '../../components/LoadingState/LoadingState'
+import { DemoBox } from '../../components/DemoBox/DemoBox'
+import { JobResultArea } from '../../components/JobResultArea/JobResultArea'
 import { useAiJob } from '../../hooks/useAiJob'
 import { useDemoConfig } from '../../hooks/useDemoConfig'
 import { useSettings } from '../../store/settingsContext'
@@ -71,8 +66,7 @@ export function RulesPanel() {
       </p>
 
       {chips.length > 0 && (
-        <div className={styles.demoBox}>
-          <h4>Try a sample question</h4>
+        <DemoBox title="Try a sample question">
           <div className={styles.chips}>
             {chips.map((chip) => (
               <button
@@ -86,7 +80,7 @@ export function RulesPanel() {
               </button>
             ))}
           </div>
-        </div>
+        </DemoBox>
       )}
 
       <textarea
@@ -106,23 +100,15 @@ export function RulesPanel() {
       </button>
 
       <div className={styles.results}>
-        {credentialError ? (
-          <ErrorState
-            message={credentialError}
-            onRetry={handleAsk}
-            hint={CREDENTIAL_HINT}
-          />
-        ) : job.isLoading ? (
-          <LoadingState message={LOADING_MESSAGE} />
-        ) : job.phase === 'error' && job.error ? (
-          <ErrorState message={job.error} onRetry={retry} hint={RETRY_HINT} />
-        ) : job.phase === 'success' && job.result ? (
-          <JobResultView feature="rules" result={job.result} />
-        ) : (
-          <p className={styles.hint}>
-            Your answer will appear here. Pick a sample question or ask your own.
-          </p>
-        )}
+        <JobResultArea
+          job={job}
+          feature="rules"
+          loadingMessage={LOADING_MESSAGE}
+          onJobRetry={retry}
+          credentialError={credentialError}
+          onCredentialRetry={handleAsk}
+          emptyHint="Your answer will appear here. Pick a sample question or ask your own."
+        />
       </div>
     </section>
   )

--- a/frontend/src/features/strategicPlan/StrategyPanel.module.css
+++ b/frontend/src/features/strategicPlan/StrategyPanel.module.css
@@ -7,26 +7,6 @@
   line-height: 1.5;
 }
 
-.demoBox {
-  background: rgba(255, 255, 255, 0.02);
-  border: 1px solid rgba(95, 208, 255, 0.12);
-  border-radius: 5px;
-  padding: 12px 16px;
-  margin: 0 0 20px;
-}
-
-.demoBox h4 {
-  margin: 0 0 8px;
-  color: var(--text-muted);
-}
-
-.demoDesc {
-  margin: 0 0 12px;
-  color: var(--text-muted);
-  line-height: 1.5;
-}
-
-.demoButton,
 .generate,
 .getStrategy {
   font-family: 'Orbitron', sans-serif;
@@ -39,14 +19,12 @@
   transition: 0.15s ease;
 }
 
-.demoButton:hover:not(:disabled),
 .generate:hover:not(:disabled),
 .getStrategy:hover:not(:disabled) {
   background: #8fe0ff;
   box-shadow: 0 0 16px rgba(95, 208, 255, 0.4);
 }
 
-.demoButton:disabled,
 .generate:disabled,
 .getStrategy:disabled {
   opacity: 0.5;
@@ -76,11 +54,11 @@
   margin-top: 20px;
 }
 
-.hint {
-  margin: 0;
-  padding: 15px;
-  background: rgba(95, 208, 255, 0.04);
-  border: 1px solid rgba(95, 208, 255, 0.18);
-  border-radius: 6px;
-  color: var(--text-muted);
+/* Mobile: stack the TTS input above its Generate button instead of squeezing
+   them onto one row. */
+@media (max-width: 640px) {
+  .ttsRow {
+    flex-direction: column;
+    align-items: stretch;
+  }
 }

--- a/frontend/src/features/strategicPlan/StrategyPanel.tsx
+++ b/frontend/src/features/strategicPlan/StrategyPanel.tsx
@@ -1,14 +1,10 @@
 import { useState } from 'react'
 
 import { Board } from '../../components/Board/Board'
-import {
-  CREDENTIAL_HINT,
-  ErrorState,
-  RETRY_HINT,
-} from '../../components/ErrorState/ErrorState'
+import { DemoBox } from '../../components/DemoBox/DemoBox'
+import { ErrorState } from '../../components/ErrorState/ErrorState'
 import { FactionSelect } from '../../components/FactionSelect/FactionSelect'
-import { JobResultView } from '../../components/JobResultView/JobResultView'
-import { LoadingState } from '../../components/LoadingState/LoadingState'
+import { JobResultArea } from '../../components/JobResultArea/JobResultArea'
 import { ResetButton } from '../../components/ResetButton/ResetButton'
 import { useDemoConfig } from '../../hooks/useDemoConfig'
 import { useResultScroll } from '../../hooks/useResultScroll'
@@ -56,21 +52,16 @@ export function StrategyPanel() {
         setup.
       </p>
 
-      <div className={styles.demoBox}>
-        <h4>Or load a sample board (instant)</h4>
-        <p className={styles.demoDesc}>
-          {demoScenario?.description ??
-            'Loads a balanced sample board, auto-selects a faction, and shows a saved strategy.'}
-        </p>
-        <button
-          type="button"
-          className={styles.demoButton}
-          onClick={handleDemo}
-          disabled={!demoReady || busy}
-        >
-          Load Sample Milty Draft Board
-        </button>
-      </div>
+      <DemoBox
+        title="Or load a sample board (instant)"
+        description={
+          demoScenario?.description ??
+          'Loads a balanced sample board, auto-selects a faction, and shows a saved strategy.'
+        }
+        buttonLabel="Load Sample Milty Draft Board"
+        onClick={handleDemo}
+        disabled={!demoReady || busy}
+      />
 
       <p className={styles.byok}>
         Have your own TTS String? Generate a game (6 player only):{' '}
@@ -123,24 +114,15 @@ export function StrategyPanel() {
       <Board game={game} />
 
       <div className={styles.results} ref={resultsRef}>
-        {credentialError ? (
-          <ErrorState
-            message={credentialError}
-            onRetry={board.suggest}
-            hint={CREDENTIAL_HINT}
-          />
-        ) : job.isLoading ? (
-          <LoadingState message={LOADING_MESSAGE} />
-        ) : job.phase === 'error' && job.error ? (
-          <ErrorState message={job.error} onRetry={board.retry} hint={RETRY_HINT} />
-        ) : job.phase === 'success' && job.result ? (
-          <JobResultView feature="strategy" result={job.result} />
-        ) : (
-          <p className={styles.hint}>
-            Your strategy will appear here. Load the sample board above, or paste a TTS
-            string and click Generate, then Get Strategy.
-          </p>
-        )}
+        <JobResultArea
+          job={job}
+          feature="strategy"
+          loadingMessage={LOADING_MESSAGE}
+          onJobRetry={board.retry}
+          credentialError={credentialError}
+          onCredentialRetry={board.suggest}
+          emptyHint="Your strategy will appear here. Load the sample board above, or paste a TTS string and click Generate, then Get Strategy."
+        />
       </div>
     </section>
   )

--- a/frontend/src/features/tacticalMove/MovePanel.module.css
+++ b/frontend/src/features/tacticalMove/MovePanel.module.css
@@ -7,26 +7,6 @@
   line-height: 1.5;
 }
 
-.demoBox {
-  background: rgba(255, 255, 255, 0.02);
-  border: 1px solid rgba(95, 208, 255, 0.12);
-  border-radius: 5px;
-  padding: 12px 16px;
-  margin: 0 0 20px;
-}
-
-.demoBox h4 {
-  margin: 0 0 8px;
-  color: var(--text-muted);
-}
-
-.demoDesc {
-  margin: 0 0 12px;
-  color: var(--text-muted);
-  line-height: 1.5;
-}
-
-.demoButton,
 .suggest {
   font-family: 'Orbitron', sans-serif;
   background: var(--accent-cyan);
@@ -38,13 +18,11 @@
   transition: 0.15s ease;
 }
 
-.demoButton:hover:not(:disabled),
 .suggest:hover:not(:disabled) {
   background: #8fe0ff;
   box-shadow: 0 0 16px rgba(95, 208, 255, 0.4);
 }
 
-.demoButton:disabled,
 .suggest:disabled {
   opacity: 0.5;
   cursor: not-allowed;
@@ -52,13 +30,4 @@
 
 .results {
   margin-top: 20px;
-}
-
-.hint {
-  margin: 0;
-  padding: 15px;
-  background: rgba(95, 208, 255, 0.04);
-  border: 1px solid rgba(95, 208, 255, 0.18);
-  border-radius: 6px;
-  color: var(--text-muted);
 }

--- a/frontend/src/features/tacticalMove/MovePanel.tsx
+++ b/frontend/src/features/tacticalMove/MovePanel.tsx
@@ -1,14 +1,9 @@
 import { useEffect } from 'react'
 
 import { Board } from '../../components/Board/Board'
-import {
-  CREDENTIAL_HINT,
-  ErrorState,
-  RETRY_HINT,
-} from '../../components/ErrorState/ErrorState'
+import { DemoBox } from '../../components/DemoBox/DemoBox'
 import { FactionSelect } from '../../components/FactionSelect/FactionSelect'
-import { JobResultView } from '../../components/JobResultView/JobResultView'
-import { LoadingState } from '../../components/LoadingState/LoadingState'
+import { JobResultArea } from '../../components/JobResultArea/JobResultArea'
 import { ResetButton } from '../../components/ResetButton/ResetButton'
 import { useDemoConfig } from '../../hooks/useDemoConfig'
 import { useResultScroll } from '../../hooks/useResultScroll'
@@ -67,21 +62,16 @@ export function MovePanel({ seed }: MovePanelProps) {
         <strong>Load Tactical Puzzle</strong> to see a worked example with no setup.
       </p>
 
-      <div className={styles.demoBox}>
-        <h4>Or load a sample puzzle (instant)</h4>
-        <p className={styles.demoDesc}>
-          {demoScenario?.description ??
-            'Loads a sample board, selects a faction, and shows a saved move recommendation.'}
-        </p>
-        <button
-          type="button"
-          className={styles.demoButton}
-          onClick={() => void board.loadDemo(demoScenario)}
-          disabled={!demoReady || busy}
-        >
-          Load Tactical Puzzle
-        </button>
-      </div>
+      <DemoBox
+        title="Or load a sample puzzle (instant)"
+        description={
+          demoScenario?.description ??
+          'Loads a sample board, selects a faction, and shows a saved move recommendation.'
+        }
+        buttonLabel="Load Tactical Puzzle"
+        onClick={() => void board.loadDemo(demoScenario)}
+        disabled={!demoReady || busy}
+      />
 
       <FactionSelect
         players={game?.players ?? []}
@@ -103,24 +93,15 @@ export function MovePanel({ seed }: MovePanelProps) {
       <Board game={game} />
 
       <div className={styles.results} ref={resultsRef}>
-        {credentialError ? (
-          <ErrorState
-            message={credentialError}
-            onRetry={board.suggest}
-            hint={CREDENTIAL_HINT}
-          />
-        ) : job.isLoading ? (
-          <LoadingState message={LOADING_MESSAGE} />
-        ) : job.phase === 'error' && job.error ? (
-          <ErrorState message={job.error} onRetry={board.retry} hint={RETRY_HINT} />
-        ) : job.phase === 'success' && job.result ? (
-          <JobResultView feature="move" result={job.result} />
-        ) : (
-          <p className={styles.hint}>
-            Your recommended move will appear here. Load the tactical puzzle above, or
-            export a board from the Fleet Manager, then pick a faction and Suggest Move.
-          </p>
-        )}
+        <JobResultArea
+          job={job}
+          feature="move"
+          loadingMessage={LOADING_MESSAGE}
+          onJobRetry={board.retry}
+          credentialError={credentialError}
+          onCredentialRetry={board.suggest}
+          emptyHint="Your recommended move will appear here. Load the tactical puzzle above, or export a board from the Fleet Manager, then pick a faction and Suggest Move."
+        />
       </div>
     </section>
   )

--- a/scripts/check_model_availability.py
+++ b/scripts/check_model_availability.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Check that every model Oracle Rex depends on is still served by its provider.
+
+This is the "Layer 2" backstop from .features/done/api_model_retirement_monitor.md:
+provider deprecation emails (Layer 1) are the source of truth, but this catches
+anything those miss, grounded in the model lists the app actually uses.
+
+The watch list is ``core/service/ai/config.py`` itself (OPENAI_MODELS /
+XAI_MODELS / ANTHROPIC_MODELS / GEMINI_MODELS), imported here so the two can
+never drift. For each provider we call its public list-models endpoint and check
+that each configured id still appears.
+
+Matching is prefix/date aware: a configured id counts as present if a live id is
+exactly it, or is it followed by a dash and a date-like snapshot suffix (e.g.
+configured ``claude-haiku-4-5`` matches live ``claude-haiku-4-5-20251001``). The
+date-suffix guard is deliberate: a naive prefix match would let ``gpt-5.4-mini``
+satisfy a retired ``gpt-5.4``, hiding exactly the kind of retirement we want to
+catch.
+
+Exit codes (any non-zero fails the GitHub Actions job, which emails the owner):
+  0  every configured model is present on every checked provider
+  1  at least one configured model is missing / retired  (the real alert)
+  2  a provider could not be checked (missing key or API error) and no missing
+     model was found  (a setup problem worth surfacing)
+
+Stdlib only, so the workflow needs no dependency install. Read-only model-list
+lookups: no inference is run, so the calls are cheap and safe.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+# Import the app's own config so the watch list is the single source of truth.
+# config.py imports only the stdlib, so no Django setup is needed.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from core.service.ai import config  # noqa: E402
+
+REQUEST_TIMEOUT = 30  # seconds; a model-list lookup should be near-instant
+
+
+# A date-like snapshot suffix: "20251001" or "2025-10-01". Used to tell a dated
+# alias of a configured model from a different model that merely shares a prefix.
+_DATE_SUFFIX = re.compile(r"\d{4}-?\d{2}-?\d{2}")
+
+
+def _openai_shape(data: dict) -> list[str]:
+    """OpenAI / xAI / Anthropic all return {"data": [{"id": ...}, ...]}."""
+    return [m["id"] for m in data.get("data", []) if m.get("id")]
+
+
+def _gemini_shape(data: dict) -> list[str]:
+    """Gemini returns {"models": [{"name": "models/<id>"}, ...]}."""
+    return [
+        m["name"].removeprefix("models/")
+        for m in data.get("models", [])
+        if m.get("name")
+    ]
+
+
+# Each provider: the configured models to check, the env var holding its key, the
+# list-models endpoint, how to build auth headers, and how to pull ids out of the
+# response. All three OpenAI-style providers share one response shape; Gemini
+# differs. Large page sizes are requested so the current (small) model sets come
+# back in a single page.
+PROVIDERS = [
+    {
+        "name": "OpenAI",
+        "models": config.OPENAI_MODELS,
+        "env": "OPENAI_API_KEY",
+        "url": "https://api.openai.com/v1/models",
+        "headers": lambda key: {"Authorization": f"Bearer {key}"},
+        "extract": _openai_shape,
+    },
+    {
+        "name": "xAI",
+        "models": config.XAI_MODELS,
+        "env": "XAI_API_KEY",
+        "url": "https://api.x.ai/v1/models",
+        "headers": lambda key: {"Authorization": f"Bearer {key}"},
+        "extract": _openai_shape,
+    },
+    {
+        "name": "Anthropic",
+        "models": config.ANTHROPIC_MODELS,
+        "env": "ANTHROPIC_API_KEY",
+        "url": "https://api.anthropic.com/v1/models?limit=1000",
+        "headers": lambda key: {
+            "x-api-key": key,
+            "anthropic-version": "2023-06-01",
+        },
+        "extract": _openai_shape,
+    },
+    {
+        "name": "Google",
+        "models": config.GEMINI_MODELS,
+        "env": "GEMINI_API_KEY",
+        "url": "https://generativelanguage.googleapis.com/v1beta/models?pageSize=1000",
+        "headers": lambda key: {"x-goog-api-key": key},
+        "extract": _gemini_shape,
+    },
+]
+
+
+def is_present(configured: str, live_ids: list[str]) -> bool:
+    """True if ``configured`` matches a live id exactly or as a dated alias."""
+    for live in live_ids:
+        if live == configured:
+            return True
+        if live.startswith(configured + "-"):
+            suffix = live[len(configured) + 1 :]
+            if _DATE_SUFFIX.fullmatch(suffix):
+                return True
+    return False
+
+
+def fetch_live_ids(provider: dict, key: str) -> list[str]:
+    """Call the provider's list-models endpoint and return its live model ids."""
+    req = urllib.request.Request(
+        provider["url"],
+        headers={"User-Agent": "oracle-rex-model-monitor", **provider["headers"](key)},
+    )
+    with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT) as resp:
+        data = json.load(resp)
+    return provider["extract"](data)
+
+
+def check_provider(provider: dict, allow_missing_keys: bool) -> tuple[str, list[str]]:
+    """Check one provider. Returns (status, missing_models).
+
+    status is one of: "ok", "missing" (some configured models gone),
+    "skipped" (no key and that's allowed), or "error" (no key / API failure).
+    """
+    name = provider["name"]
+    configured = provider["models"]
+    if not configured:
+        print(f"  {name}: no models configured, skipping")
+        return "ok", []
+
+    key = os.environ.get(provider["env"], "").strip()
+    # config.py seeds GEMINI_API_KEY with a "<PLACEHOLDER>" sentinel for local
+    # use; treat that as unset.
+    if not key or key.startswith("<"):
+        if allow_missing_keys:
+            print(f"  {name}: {provider['env']} not set, skipping (--allow-missing-keys)")
+            return "skipped", []
+        print(f"  {name}: ERROR {provider['env']} not set")
+        return "error", []
+
+    try:
+        live_ids = fetch_live_ids(provider, key)
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", "replace")[:200]
+        print(f"  {name}: ERROR HTTP {exc.code} from list-models endpoint: {body}")
+        return "error", []
+    except (urllib.error.URLError, OSError, ValueError) as exc:
+        print(f"  {name}: ERROR could not reach list-models endpoint: {exc}")
+        return "error", []
+
+    missing = [m for m in configured if not is_present(m, live_ids)]
+    if missing:
+        present = [m for m in configured if m not in missing]
+        print(f"  {name}: MISSING {missing}  (still present: {present})")
+        return "missing", missing
+    print(f"  {name}: all {len(configured)} configured models present")
+    return "ok", []
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--allow-missing-keys",
+        action="store_true",
+        help="Skip (instead of failing on) providers whose API key env var is unset. "
+        "Useful for local runs with only a subset of keys; CI should not pass this.",
+    )
+    args = parser.parse_args()
+
+    print("Checking configured models against live provider model lists...")
+    any_missing = False
+    any_uncheckable = False
+    for provider in PROVIDERS:
+        status, _ = check_provider(provider, args.allow_missing_keys)
+        if status == "missing":
+            any_missing = True
+        elif status == "error":
+            any_uncheckable = True
+
+    print()
+    if any_missing:
+        print(
+            "RESULT: one or more configured models are no longer served. Update "
+            "core/service/ai/config.py (and frontend model lists) and check the "
+            "provider's deprecation notice for a replacement."
+        )
+        return 1
+    if any_uncheckable:
+        print(
+            "RESULT: no missing models found, but a provider could not be checked "
+            "(see ERROR lines above). Fix the key/secret or endpoint and re-run."
+        )
+        return 2
+    print("RESULT: all configured models are present on every provider.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
…eanup

React DRY cleanup:
- Extract JobResultArea, DemoBox, and EmptyHint components and route RulesPanel/StrategyPanel/MovePanel/BattleCalculator through them; remove the duplicated demo-box/hint CSS from the four panel modules.

API/model retirement monitor:
- Add scripts/check_model_availability.py (stdlib-only, imports config.py as the watch list; prefix/date-aware matching across OpenAI, xAI, Anthropic, Google).
- Add .github/workflows/model-retirement-check.yml (weekly cron + dispatch).

Mobile / small-screen UI (all behind max-width:640px; desktop unchanged):
- TabNav wraps to two rows so all six tabs stay reachable.
- Board grid box fits the viewport width and drops the 160vh height balloon; hex size unchanged so desktop is pixel-identical.
- Reduce shell padding, stack fleet columns and the TTS input row.

Docs:
- Move completed plans into .features/done/; add .claude/launch.json.