### PR TITLE
Fix promptfoo rules eval (expected_rule_ids encoding + Node-compatible pin)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,8 @@ core/data/index/
 # ingested locally by scripts/ingest_lrr.py. See .features/rules_rag_grounding.md.
 *.pdf
 lrr*.pdf
+
+# promptfoo run artifacts when the eval is run from the repo root (the committed
+# record is evals/BASELINES.md; reports/cache stay local).
+/promptfoo-errors.log
+/.promptfoo/

--- a/evals/BASELINES.md
+++ b/evals/BASELINES.md
@@ -27,7 +27,7 @@ is the free-tier Gemini model.
 ```powershell
 python manage.py build_rules_index                 # grounding needs the index
 $env:PROMPTFOO_PYTHON = ".\.venv\Scripts\python.exe"
-npx promptfoo@0.121.17 eval -c evals/promptfooconfig.rules.yaml
+npx promptfoo@0.118.0 eval -c evals/promptfooconfig.rules.yaml
 ```
 
 | Date | Model | Prompt | Cases | pipeline_schema pass | cited_rules pass | Notable failures |

--- a/evals/README.md
+++ b/evals/README.md
@@ -45,8 +45,10 @@ mocks can't — the actual model behavior behind each prompt version.
   python manage.py build_rules_index
   ```
 
-- **Pinned promptfoo version:** `promptfoo@0.121.17`. Pin it on every invocation
-  so runs are reproducible.
+- **Pinned promptfoo version:** `promptfoo@0.118.0`. Pin it on every invocation
+  so runs are reproducible. (Pinned here because `0.121+` requires Node
+  `^20.20.0 || >=22.22.0`; `0.118.0` needs only Node `>=18`, matching this repo's
+  Node `22.14.0`. Bump both together if you move Node forward.)
 
 ### Keys (environment)
 
@@ -93,20 +95,18 @@ From the **repo root** (so `.venv` and `.env` resolve):
 
 ```powershell
 # Rules Q&A, default Gemini provider
-npx promptfoo@0.121.17 eval -c evals/promptfooconfig.rules.yaml
+npx promptfoo@0.118.0 eval -c evals/promptfooconfig.rules.yaml
 
 # Open the last run in the local web viewer
-npx promptfoo@0.121.17 view
+npx promptfoo@0.118.0 view
 ```
 
-### Cheap iteration (smoke subset)
+### Cheap iteration (a few cases)
 
-While editing a prompt, run only the cases tagged `smoke: true` (3 of them):
+While editing a prompt, run just the first few cases to keep token cost trivial:
 
 ```powershell
-npx promptfoo@0.121.17 eval -c evals/promptfooconfig.rules.yaml --filter-metadata smoke=true
-# or just the first N cases:
-npx promptfoo@0.121.17 eval -c evals/promptfooconfig.rules.yaml --filter-first-n 3
+npx promptfoo@0.118.0 eval -c evals/promptfooconfig.rules.yaml --filter-first-n 3
 ```
 
 Run the **full** set before merging a prompt change.
@@ -127,7 +127,7 @@ Run the **full** set before merging a prompt change.
 Outputs stay uncommitted. Write one when you want to diff a run:
 
 ```powershell
-npx promptfoo@0.121.17 eval -c evals/promptfooconfig.rules.yaml -o evals/output/rules-$(Get-Date -Format yyyyMMdd).json
+npx promptfoo@0.118.0 eval -c evals/promptfooconfig.rules.yaml -o evals/output/rules-$(Get-Date -Format yyyyMMdd).json
 ```
 
 ## What the assertions check

--- a/evals/asserts/cited_rules.py
+++ b/evals/asserts/cited_rules.py
@@ -29,11 +29,31 @@ def _pass(reason: str) -> dict:
     return {"pass": True, "score": 1.0, "reason": reason}
 
 
+def _expected_ids(raw) -> list:
+    """Parse expected rule ids from a promptfoo var.
+
+    The generator passes a space/comma-joined string (promptfoo would otherwise
+    expand a list var into multiple test cases), but accept a real list too so
+    the assert is robust to either shape.
+    """
+    if isinstance(raw, (list, tuple)):
+        return [str(x).strip() for x in raw if str(x).strip()]
+    return [t for t in str(raw or "").replace(",", " ").split() if t]
+
+
+def _as_bool(raw, default: bool = True) -> bool:
+    if isinstance(raw, bool):
+        return raw
+    if raw is None:
+        return default
+    return str(raw).strip().lower() not in ("false", "0", "no", "")
+
+
 def get_assert(output, context):
     context = context or {}
     vars_ = context.get("vars") or {}
-    expected = list(vars_.get("expected_rule_ids") or [])
-    grounded_expected = vars_.get("grounded_expected", True)
+    expected = _expected_ids(vars_.get("expected_rule_ids"))
+    grounded_expected = _as_bool(vars_.get("grounded_expected", True))
 
     try:
         payload = json.loads(output) if isinstance(output, str) else output

--- a/evals/cases/rules.yaml
+++ b/evals/cases/rules.yaml
@@ -12,236 +12,192 @@
   vars:
     question: What happens if two players have abilities that trigger at the same
       timing window?
-    expected_rule_ids:
-    - '1.19'
+    expected_rule_ids: '1.19'
     grounded_expected: true
 - description: 'retreat-no-ships: Can I retreat from space combat if I have no ships
     left?'
   vars:
     question: Can I retreat from space combat if I have no ships left?
-    expected_rule_ids:
-    - '78.7'
+    expected_rule_ids: '78.7'
     grounded_expected: true
 - description: 'production-capacity: How does production capacity work?'
   vars:
     question: How does production capacity work?
-    expected_rule_ids:
-    - '16.1'
+    expected_rule_ids: '16.1'
     grounded_expected: true
 - description: 'tactical-action-newbie: Explain how tactical actions work like I''m
     new to TI.'
   vars:
     question: Explain how tactical actions work like I'm new to TI.
-    expected_rule_ids:
-    - '89'
+    expected_rule_ids: '89'
     grounded_expected: true
 - description: 'announce-retreat: When during space combat do I announce a retreat?'
   vars:
     question: When during space combat do I announce a retreat?
-    expected_rule_ids:
-    - '78.4'
+    expected_rule_ids: '78.4'
     grounded_expected: true
 - description: 'excess-fighters: At the end of a space combat I have more fighters
     than my remaining capacity. What happens to the excess?'
   vars:
     question: At the end of a space combat I have more fighters than my remaining
       capacity. What happens to the excess?
-    expected_rule_ids:
-    - '16.3'
+    expected_rule_ids: '16.3'
     grounded_expected: true
 - description: 'sustain-damage-use: How and when can a unit use Sustain Damage?'
   vars:
     question: How and when can a unit use Sustain Damage?
-    expected_rule_ids:
-    - '87'
-    - '87.4'
+    expected_rule_ids: 87 87.4
     grounded_expected: true
 - description: 'nebula-rules: Can ships move into a nebula, and does it affect combat?'
   vars:
     question: Can ships move into a nebula, and does it affect combat?
-    expected_rule_ids:
-    - '59.1'
-    - '59.3'
+    expected_rule_ids: 59.1 59.3
     grounded_expected: true
 - description: 'transaction-neighbors: Who can I make a transaction with, and how
     often per turn?'
   vars:
     question: Who can I make a transaction with, and how often per turn?
-    expected_rule_ids:
-    - '94.1'
+    expected_rule_ids: '94.1'
     grounded_expected: true
 - description: 'afb-timing: When does Anti-Fighter Barrage happen and what can it
     hit?'
   vars:
     question: When does Anti-Fighter Barrage happen and what can it hit?
-    expected_rule_ids:
-    - '78.3'
-    - '10.2'
+    expected_rule_ids: 78.3 10.2
     grounded_expected: true
 - description: 'objectives-per-status: How many objectives can I score in a single
     status phase?'
   vars:
     question: How many objectives can I score in a single status phase?
-    expected_rule_ids:
-    - '61.6'
+    expected_rule_ids: '61.6'
     grounded_expected: true
 - description: 'custodians-mecatol: What do I have to do to land ground forces on
     Mecatol Rex the first time?'
   vars:
     question: What do I have to do to land ground forces on Mecatol Rex the first
       time?
-    expected_rule_ids:
-    - '27.2'
+    expected_rule_ids: '27.2'
     grounded_expected: true
 - description: 'production-limit: How does a unit''s Production value limit what I
     can build?'
   vars:
     question: How does a unit's Production value limit what I can build?
-    expected_rule_ids:
-    - '68.1'
+    expected_rule_ids: '68.1'
     grounded_expected: true
 - description: 'assign-hits-space: How do I assign and resolve hits during space combat?'
   vars:
     question: How do I assign and resolve hits during space combat?
-    expected_rule_ids:
-    - '78.6'
+    expected_rule_ids: '78.6'
     grounded_expected: true
 - description: 'ground-combat: How does ground combat work during an invasion?'
   vars:
     question: How does ground combat work during an invasion?
-    expected_rule_ids:
-    - '42'
+    expected_rule_ids: '42'
     grounded_expected: true
 - description: 'bombardment-planetary-shield: Can I bombard a planet that has Planetary
     Shield?'
   vars:
     question: Can I bombard a planet that has Planetary Shield?
-    expected_rule_ids:
-    - '65'
+    expected_rule_ids: '65'
     grounded_expected: true
 - description: 'space-cannon-offense-timing: When exactly can PDS use Space Cannon
     Offense during a tactical action?'
   vars:
     question: When exactly can PDS use Space Cannon Offense during a tactical action?
-    expected_rule_ids:
-    - '77'
-    - '58.7'
+    expected_rule_ids: 77 58.7
     grounded_expected: true
 - description: 'tactical-action-steps: What are the steps of a tactical action, in
     order?'
   vars:
     question: What are the steps of a tactical action, in order?
-    expected_rule_ids:
-    - '89'
+    expected_rule_ids: '89'
     grounded_expected: true
 - description: 'command-tokens-pools: How do command tokens work across the three
     pools?'
   vars:
     question: How do command tokens work across the three pools?
-    expected_rule_ids:
-    - '20.1'
-    - '20.2'
+    expected_rule_ids: 20.1 20.2
     grounded_expected: true
 - description: 'commodities-conversion: How do commodities turn into trade goods?'
   vars:
     question: How do commodities turn into trade goods?
-    expected_rule_ids:
-    - '21.6'
+    expected_rule_ids: '21.6'
     grounded_expected: true
 - description: 'move-through-enemy: Can I move my ships through a system that contains
     enemy ships?'
   vars:
     question: Can I move my ships through a system that contains enemy ships?
-    expected_rule_ids:
-    - '58.4'
+    expected_rule_ids: '58.4'
     grounded_expected: true
 - description: 'wormhole-adjacency: How do wormholes create adjacency between systems?'
   vars:
     question: How do wormholes create adjacency between systems?
-    expected_rule_ids:
-    - '6.1'
+    expected_rule_ids: '6.1'
     grounded_expected: true
 - description: 'fleet-pool-limit: What limits how many ships I can have in a system?'
   vars:
     question: What limits how many ships I can have in a system?
-    expected_rule_ids:
-    - '76.2'
-    - '37.1'
-    - '37.3'
+    expected_rule_ids: 76.2 37.1 37.3
     grounded_expected: true
 - description: 'elimination: When is a player eliminated from the game?'
   vars:
     question: When is a player eliminated from the game?
-    expected_rule_ids:
-    - '33.1'
+    expected_rule_ids: '33.1'
     grounded_expected: true
 - description: 'agenda-voting: How does voting work during the agenda phase?'
   vars:
     question: How does voting work during the agenda phase?
-    expected_rule_ids:
-    - '8.5'
+    expected_rule_ids: '8.5'
     grounded_expected: true
 - description: 'initiative-order: How is initiative order determined?'
   vars:
     question: How is initiative order determined?
-    expected_rule_ids:
-    - '48.2'
+    expected_rule_ids: '48.2'
     grounded_expected: true
 - description: 'secret-objectives: Can I score another player''s secret objective?'
   vars:
     question: Can I score another player's secret objective?
-    expected_rule_ids:
-    - '61.19'
+    expected_rule_ids: '61.19'
     grounded_expected: true
 - description: 'deploy-mechs: How do Deploy abilities work for mechs?'
   vars:
     question: How do Deploy abilities work for mechs?
-    expected_rule_ids:
-    - '55.3'
+    expected_rule_ids: '55.3'
     grounded_expected: true
 - description: 'structures-per-planet: How many PDS and space docks can I have on
     a single planet?'
   vars:
     question: How many PDS and space docks can I have on a single planet?
-    expected_rule_ids:
-    - '85.4'
-    - '85.5'
+    expected_rule_ids: 85.4 85.5
     grounded_expected: true
 - description: 'sustain-damage-timing: When exactly do I decide to use Sustain Damage
     relative to assigning hits?'
   vars:
     question: When exactly do I decide to use Sustain Damage relative to assigning
       hits?
-    expected_rule_ids:
-    - '87'
+    expected_rule_ids: '87'
     grounded_expected: true
 - description: 'blockade: What happens when my space dock is blockaded?'
   vars:
     question: What happens when my space dock is blockaded?
-    expected_rule_ids:
-    - '14'
-    - '14.2'
+    expected_rule_ids: 14 14.2
     grounded_expected: true
 - description: 'neighbors: What makes two players neighbors?'
   vars:
     question: What makes two players neighbors?
-    expected_rule_ids:
-    - '60'
+    expected_rule_ids: '60'
     grounded_expected: true
 - description: 'transport-pickup: When moving a ship with capacity, can I pick up
     infantry on a planet in a system I move through?'
   vars:
     question: When moving a ship with capacity, can I pick up infantry on a planet
       in a system I move through?
-    expected_rule_ids:
-    - '95.1'
+    expected_rule_ids: '95.1'
     grounded_expected: true
 - description: 'transport-dropoff: When moving a ship with capacity, can I drop off
     infantry on a planet I move through before reaching my destination?'
   vars:
     question: When moving a ship with capacity, can I drop off infantry on a planet
       I move through before reaching my destination?
-    expected_rule_ids:
-    - '95.1'
-    - '58.4'
+    expected_rule_ids: 95.1 58.4
     grounded_expected: true

--- a/scripts/build_promptfoo_rules_cases.py
+++ b/scripts/build_promptfoo_rules_cases.py
@@ -46,7 +46,11 @@ def build_cases(golden: dict) -> list[dict]:
                 "description": f"{c['id']}: {c['question']}",
                 "vars": {
                     "question": c["question"],
-                    "expected_rule_ids": list(c["expected_rule_ids"]),
+                    # Space-joined string, NOT a YAML list: promptfoo expands a
+                    # list-valued var into a Cartesian product of test cases (and
+                    # unwraps a single-element list to a bare string), which would
+                    # shred "1.19" into characters. cited_rules.py splits this back.
+                    "expected_rule_ids": " ".join(c["expected_rule_ids"]),
                     # In-corpus golden questions expect a grounded answer; a case
                     # may set "grounded": false to assert the ungrounded path.
                     "grounded_expected": bool(c.get("grounded", True)),


### PR DESCRIPTION
Follow-up to #9. The first live Tier B run passed on the pipeline but failed on the harness — two issues, both fixed here. The RAG pipeline itself was correct (every case retrieved and cited the right rule).

## What was wrong
1. **`expected_rule_ids` was a YAML list.** promptfoo expands a list-valued var into a Cartesian product of test cases and unwraps a single-element list to a bare string — so `['1.19']` reached the assert as `"1.19"`, and `list("1.19")` shredded it into `['1','.','1','9']`, failing every case even though the answer cited `1.19` correctly.
   - The generator now emits a **space-joined string**; `cited_rules.py` splits it back (robust to string or list) and coerces `grounded_expected`.
2. **Node-incompatible version pin.** `promptfoo@0.121.17` requires Node `^20.20.0 || >=22.22.0`, but the repo runs on Node `22.14.0` (matching Render). Repinned the runbook to **`0.118.0`** (needs only Node `>=18`) and corrected the cheap-iteration note (golden-generated cases carry no `smoke` tag → use `--filter-first-n`).

Also gitignores the root-level promptfoo run artifacts.

## Verified
- Re-ran the 3-case smoke set → **passing** (owner-confirmed).
- Simulated the fixed assert against the literal cited sets from the failing run (`1.19`, `78.7`, `16.1`, plus a multi-id case) → all pass.
- Backend suite unaffected (changes are eval-only; the golden JSON stays a proper list for the Tier A pytest eval).

🤖 Generated with [Claude Code](https://claude.com/claude-code)